### PR TITLE
security: add checksum verification and safe .env parser (v0.1.3)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,18 +48,54 @@ get_latest_version() {
 
 download_binary() {
     local url="https://github.com/$REPO/releases/download/$VERSION/nexus-${OS}-${ARCH}"
+    local checksum_url="https://github.com/$REPO/releases/download/$VERSION/checksums.txt"
     local dest="$INSTALL_DIR/nexus"
+    local checksum_file
+    checksum_file="$(mktemp)"
 
     mkdir -p "$INSTALL_DIR"
 
     info "Downloading nexus $VERSION ($OS/$ARCH)..."
     if command -v curl &>/dev/null; then
         curl -sSL "$url" -o "$dest"
+        curl -sSL "$checksum_url" -o "$checksum_file"
     else
         wget -qO "$dest" "$url"
+        wget -qO "$checksum_file" "$checksum_url"
     fi
+
+    info "Verifying checksum..."
+    local binary_name="nexus-${OS}-${ARCH}"
+    if command -v sha256sum &>/dev/null; then
+        # Extract expected hash for this binary and verify
+        local expected
+        expected=$(grep "$binary_name" "$checksum_file" | awk '{print $1}')
+        if [ -z "$expected" ]; then
+            rm -f "$checksum_file"
+            fail "Checksum entry for $binary_name not found in checksums.txt"
+        fi
+        echo "$expected  $dest" | sha256sum --check --status || {
+            rm -f "$dest" "$checksum_file"
+            fail "Checksum verification failed — binary may be corrupted or tampered with"
+        }
+    elif command -v shasum &>/dev/null; then
+        local expected
+        expected=$(grep "$binary_name" "$checksum_file" | awk '{print $1}')
+        if [ -z "$expected" ]; then
+            rm -f "$checksum_file"
+            fail "Checksum entry for $binary_name not found in checksums.txt"
+        fi
+        echo "$expected  $dest" | shasum -a 256 --check --status || {
+            rm -f "$dest" "$checksum_file"
+            fail "Checksum verification failed — binary may be corrupted or tampered with"
+        }
+    else
+        warn "Neither sha256sum nor shasum found — skipping checksum verification"
+    fi
+
+    rm -f "$checksum_file"
     chmod +x "$dest"
-    ok "Installed to $dest"
+    ok "Checksum verified. Installed to $dest"
 }
 
 clone_repo() {

--- a/install.sh
+++ b/install.sh
@@ -69,9 +69,9 @@ download_binary() {
     if command -v sha256sum &>/dev/null; then
         # Extract expected hash for this binary and verify
         local expected
-        expected=$(grep "$binary_name" "$checksum_file" | awk '{print $1}')
+        expected=$(grep "^${binary_name} " "$checksum_file" | awk '{print $1}')
         if [ -z "$expected" ]; then
-            rm -f "$checksum_file"
+            rm -f "$dest" "$checksum_file"
             fail "Checksum entry for $binary_name not found in checksums.txt"
         fi
         echo "$expected  $dest" | sha256sum --check --status || {
@@ -80,9 +80,9 @@ download_binary() {
         }
     elif command -v shasum &>/dev/null; then
         local expected
-        expected=$(grep "$binary_name" "$checksum_file" | awk '{print $1}')
+        expected=$(grep "^${binary_name} " "$checksum_file" | awk '{print $1}')
         if [ -z "$expected" ]; then
-            rm -f "$checksum_file"
+            rm -f "$dest" "$checksum_file"
             fail "Checksum entry for $binary_name not found in checksums.txt"
         fi
         echo "$expected  $dest" | shasum -a 256 --check --status || {

--- a/tools/automation/ollama-delegate.sh
+++ b/tools/automation/ollama-delegate.sh
@@ -23,8 +23,34 @@
 
 set -euo pipefail
 
-# Load local .env overrides if present (relative to repo root)
-[ -f "$(dirname "$0")/../../.env" ] && source "$(dirname "$0")/../../.env"
+# Load local .env overrides if present (relative to repo root).
+# Parses only KEY=VALUE lines — does not execute shell code.
+_load_env() {
+    local env_file="$1"
+    [ -f "$env_file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Skip blank lines and comments
+        [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        # Reject lines containing command substitution or backticks
+        if [[ "$line" =~ \$\( ]] || [[ "$line" =~ \` ]]; then
+            echo "WARN: Skipping unsafe .env line: $line" >&2
+            continue
+        fi
+        # Accept only KEY=VALUE (KEY may contain letters, digits, underscores)
+        if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+            local key="${line%%=*}"
+            local value="${line#*=}"
+            # Strip surrounding quotes if present
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            export "$key=$value"
+        fi
+    done < "$env_file"
+}
+_load_env "$(dirname "$0")/../../.env"
 
 TASK_TYPE="${1:-}"
 CONTEXT_FILE="${2:-}"

--- a/tools/automation/ollama-delegate.sh
+++ b/tools/automation/ollama-delegate.sh
@@ -43,10 +43,11 @@ _load_env() {
         if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
             local key="${line%%=*}"
             local value="${line#*=}"
-            # Strip surrounding quotes only if they match as a pair
-            if [[ "$value" =~ ^\".*\"$ ]] || [[ "$value" =~ ^\'.*\'$ ]]; then
-                value="${value:1:-1}"
-            fi
+            # Strip surrounding quotes only if they match as a pair (Bash 3.2 portable)
+            case "$value" in
+                \"*\") value="${value#\"}"; value="${value%\"}" ;;
+                \'*\') value="${value#\'}"; value="${value%\'}" ;;
+            esac
             export "$key=$value"
         fi
     done < "$env_file"

--- a/tools/automation/ollama-delegate.sh
+++ b/tools/automation/ollama-delegate.sh
@@ -28,24 +28,25 @@ set -euo pipefail
 _load_env() {
     local env_file="$1"
     [ -f "$env_file" ] || return 0
+    local lineno=0
     while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
         # Skip blank lines and comments
         [[ "$line" =~ ^[[:space:]]*$ ]] && continue
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
         # Reject lines containing command substitution or backticks
         if [[ "$line" =~ \$\( ]] || [[ "$line" =~ \` ]]; then
-            echo "WARN: Skipping unsafe .env line: $line" >&2
+            echo "WARN: Skipping unsafe .env line at ${lineno}" >&2
             continue
         fi
         # Accept only KEY=VALUE (KEY may contain letters, digits, underscores)
         if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
             local key="${line%%=*}"
             local value="${line#*=}"
-            # Strip surrounding quotes if present
-            value="${value%\"}"
-            value="${value#\"}"
-            value="${value%\'}"
-            value="${value#\'}"
+            # Strip surrounding quotes only if they match as a pair
+            if [[ "$value" =~ ^\".*\"$ ]] || [[ "$value" =~ ^\'.*\'$ ]]; then
+                value="${value:1:-1}"
+            fi
             export "$key=$value"
         fi
     done < "$env_file"


### PR DESCRIPTION
## Summary

Closes #6 and #7 — completes the v0.1.3 Security Hardening milestone.

## Changes

### `install.sh` — checksum verification (fixes #6)

GoReleaser publishes `checksums.txt` alongside each release binary. This change:
- Downloads `checksums.txt` from the same release tag
- Extracts the expected SHA256 for the platform binary
- Verifies with `sha256sum` (Linux) or `shasum -a 256` (macOS)
- Fails hard and removes the binary if verification fails
- Warns (but continues) if neither tool is available

### `tools/automation/ollama-delegate.sh` — safe `.env` parser (fixes #7)

Replaces `source .env` with a line-by-line parser (`_load_env`) that:
- Skips blank lines and comments
- Rejects any line containing `$(` or backticks
- Accepts only `KEY=VALUE` lines matching `[A-Za-z_][A-Za-z0-9_]*=`
- Strips surrounding single/double quotes from values
- Uses `export` to set each variable

## Testing

- Both files pass `bash -n` syntax check
- Checksum path tested against a real release asset URL pattern
- `.env` parser rejects `FOO=$(rm -rf /)` and `` BAR=`whoami` `` style injections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer environment file handling: ignores comments/blank lines, strips surrounding quotes, warns on unsafe constructs, and prevents execution of arbitrary shell content.

* **Chores**
  * Installer integrity checks: downloads release checksums and verifies installers with SHA-256, fails on missing/mismatched entries, cleans temporary files, and warns if verification tools are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->