### PR TITLE
fix(install): prefer shasum on macOS to avoid BSD sha256sum incompatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,25 +66,26 @@ download_binary() {
 
     info "Verifying checksum..."
     local binary_name="nexus-${OS}-${ARCH}"
-    if command -v sha256sum &>/dev/null; then
-        # Extract expected hash for this binary and verify
-        local expected
-        expected=$(awk -v name="$binary_name" '$2 == name {print $1}' "$checksum_file")
-        if [ -z "$expected" ]; then
+    local expected
+    expected=$(awk -v name="$binary_name" '$2 == name {print $1}' "$checksum_file")
+    if [ -z "$expected" ]; then
+        rm -f "$dest" "$checksum_file"
+        fail "Checksum entry for $binary_name not found in checksums.txt"
+    fi
+
+    # On macOS, BSD sha256sum does not support --check/--status; prefer shasum -a 256.
+    # On Linux, prefer sha256sum (GNU coreutils).
+    if [ "$OS" = "darwin" ] && command -v shasum &>/dev/null; then
+        echo "$expected  $dest" | shasum -a 256 --check --status || {
             rm -f "$dest" "$checksum_file"
-            fail "Checksum entry for $binary_name not found in checksums.txt"
-        fi
+            fail "Checksum verification failed — binary may be corrupted or tampered with"
+        }
+    elif command -v sha256sum &>/dev/null; then
         echo "$expected  $dest" | sha256sum --check --status || {
             rm -f "$dest" "$checksum_file"
             fail "Checksum verification failed — binary may be corrupted or tampered with"
         }
     elif command -v shasum &>/dev/null; then
-        local expected
-        expected=$(awk -v name="$binary_name" '$2 == name {print $1}' "$checksum_file")
-        if [ -z "$expected" ]; then
-            rm -f "$dest" "$checksum_file"
-            fail "Checksum entry for $binary_name not found in checksums.txt"
-        fi
         echo "$expected  $dest" | shasum -a 256 --check --status || {
             rm -f "$dest" "$checksum_file"
             fail "Checksum verification failed — binary may be corrupted or tampered with"


### PR DESCRIPTION
## Problem

Closes #33

`install.sh` fails on macOS at checksum verification:

```
==> Verifying checksum...
usage: sha256sum [-bctwz] [files ...]
  ✗ Checksum verification failed — binary may be corrupted or tampered with
```

macOS ships a BSD `sha256sum` that **does not support `--check` or `--status`** (GNU coreutils flags). Since `command -v sha256sum` succeeds on macOS, the `shasum` fallback is never reached.

## Fix

Use the `$OS` variable (already set by `detect_platform`) to prefer `shasum -a 256` on `darwin`, then fall back to `sha256sum` on Linux, with `shasum` as a final fallback. Also consolidates the duplicated `expected` hash extraction into a single block.

## Tested

- macOS arm64: checksum verification now passes using `shasum -a 256`
- Linux behavior unchanged (`sha256sum` path still taken)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Installation process checksum verification has been refined for better reliability and maintainability. Error handling is now consolidated with clearer feedback when verification fails. Cross-platform tool selection has been optimized to ensure consistent and secure binary installation across all supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->