### PR TITLE
fix: v0.1.7 security fixes — install.sh temp-file, demo PAT, doc paths

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GIF_TOKEN }}
           fetch-depth: 0
 
       - uses: actions/setup-go@v5

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,9 @@ archives:
   - formats: [binary]
     name_template: "nexus-{{ .Os }}-{{ .Arch }}"
 
+extra_files:
+  - glob: install.sh
+
 checksum:
   name_template: "checksums.txt"
 

--- a/core/NEXUS.md
+++ b/core/NEXUS.md
@@ -157,7 +157,7 @@ If any `ollama_*` tool returns `CIRCUIT_BREAKER`, fall back to handling the task
 
 If MCP is not available, the same delegation can be done manually via:
 ```bash
-bash ~/.config/nexus/tools/automation/ollama-delegate.sh <task-type> <context-file>
+bash ~/.config/nexus/tools/utilities/ollama-delegate.sh <task-type> <context-file>
 ```
 
 ---

--- a/core/kiro-nexus-steering.md
+++ b/core/kiro-nexus-steering.md
@@ -158,5 +158,5 @@ If any `ollama_*` tool returns `CIRCUIT_BREAKER`, fall back to handling the task
 
 If MCP is not available, the same delegation can be done manually via:
 ```bash
-bash ~/.config/nexus/tools/automation/ollama-delegate.sh <task-type> <context-file>
+bash ~/.config/nexus/tools/utilities/ollama-delegate.sh <task-type> <context-file>
 ```

--- a/install.sh
+++ b/install.sh
@@ -51,10 +51,11 @@ download_binary() {
     local checksum_url="https://github.com/$REPO/releases/download/$VERSION/checksums.txt"
     local dest="$INSTALL_DIR/nexus"
     local tmp_binary checksum_file
-    tmp_binary="$(mktemp)"
-    checksum_file="$(mktemp)"
 
     mkdir -p "$INSTALL_DIR"
+    tmp_binary="$(mktemp "$INSTALL_DIR/.nexus.XXXXXX")"
+    checksum_file="$(mktemp)"
+    trap 'rm -f "$tmp_binary" "$checksum_file"' EXIT
 
     info "Downloading nexus $VERSION ($OS/$ARCH)..."
     if command -v curl &>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -50,17 +50,18 @@ download_binary() {
     local url="https://github.com/$REPO/releases/download/$VERSION/nexus-${OS}-${ARCH}"
     local checksum_url="https://github.com/$REPO/releases/download/$VERSION/checksums.txt"
     local dest="$INSTALL_DIR/nexus"
-    local checksum_file
+    local tmp_binary checksum_file
+    tmp_binary="$(mktemp)"
     checksum_file="$(mktemp)"
 
     mkdir -p "$INSTALL_DIR"
 
     info "Downloading nexus $VERSION ($OS/$ARCH)..."
     if command -v curl &>/dev/null; then
-        curl -sSL "$url" -o "$dest"
+        curl -sSL "$url" -o "$tmp_binary"
         curl -sSL "$checksum_url" -o "$checksum_file"
     else
-        wget -qO "$dest" "$url"
+        wget -qO "$tmp_binary" "$url"
         wget -qO "$checksum_file" "$checksum_url"
     fi
 
@@ -69,34 +70,35 @@ download_binary() {
     local expected
     expected=$(awk -v name="$binary_name" '$2 == name {print $1}' "$checksum_file")
     if [ -z "$expected" ]; then
-        rm -f "$dest" "$checksum_file"
+        rm -f "$tmp_binary" "$checksum_file"
         fail "Checksum entry for $binary_name not found in checksums.txt"
     fi
 
     # On macOS, BSD sha256sum does not support --check/--status; prefer shasum -a 256.
     # On Linux, prefer sha256sum (GNU coreutils).
     if [ "$OS" = "darwin" ] && command -v shasum &>/dev/null; then
-        echo "$expected  $dest" | shasum -a 256 --check --status || {
-            rm -f "$dest" "$checksum_file"
+        echo "$expected  $tmp_binary" | shasum -a 256 --check --status || {
+            rm -f "$tmp_binary" "$checksum_file"
             fail "Checksum verification failed — binary may be corrupted or tampered with"
         }
     elif command -v sha256sum &>/dev/null; then
-        echo "$expected  $dest" | sha256sum --check --status || {
-            rm -f "$dest" "$checksum_file"
+        echo "$expected  $tmp_binary" | sha256sum --check --status || {
+            rm -f "$tmp_binary" "$checksum_file"
             fail "Checksum verification failed — binary may be corrupted or tampered with"
         }
     elif command -v shasum &>/dev/null; then
-        echo "$expected  $dest" | shasum -a 256 --check --status || {
-            rm -f "$dest" "$checksum_file"
+        echo "$expected  $tmp_binary" | shasum -a 256 --check --status || {
+            rm -f "$tmp_binary" "$checksum_file"
             fail "Checksum verification failed — binary may be corrupted or tampered with"
         }
     else
-        rm -f "$dest" "$checksum_file"
+        rm -f "$tmp_binary" "$checksum_file"
         fail "Neither sha256sum nor shasum found — cannot verify binary integrity. Install coreutils and retry."
     fi
 
     rm -f "$checksum_file"
-    chmod +x "$dest"
+    chmod +x "$tmp_binary"
+    mv "$tmp_binary" "$dest"
     ok "Checksum verified. Installed to $dest"
 }
 

--- a/tools/mcp/server.mjs
+++ b/tools/mcp/server.mjs
@@ -296,7 +296,7 @@ server.tool(
 server.tool(
   "ollama_commit_msg",
   "Generate a conventional commit message from a git diff using a local 1.5B model. Use this instead of writing commit messages with cloud models.",
-  { diff: z.string().describe("The git diff to summarize") },
+  { diff: z.string().max(500000).describe("The git diff to summarize") },
   async ({ diff }) => {
     // Fast-path: deterministic commit messages for trivial diffs
     const fastResult = fastPathCommitMsg(diff);
@@ -331,7 +331,7 @@ server.tool(
 server.tool(
   "ollama_boilerplate",
   "Generate a clean boilerplate file from a specification using a local 1.5B model. Use for component/route/model scaffolding.",
-  { specification: z.string().describe("Description of the boilerplate to generate, including framework and patterns to follow") },
+  { specification: z.string().max(500000).describe("Description of the boilerplate to generate, including framework and patterns to follow") },
   async ({ specification }) => {
     const model = MODEL_ROUTES["boilerplate"];
     const prompt = PROMPTS["boilerplate"](specification);
@@ -360,7 +360,7 @@ server.tool(
 server.tool(
   "ollama_test_scaffold",
   "Generate a test file scaffold (describe blocks, test names, no implementations) from a source file using a local 1.5B model.",
-  { source_code: z.string().describe("The source file content to generate tests for") },
+  { source_code: z.string().max(500000).describe("The source file content to generate tests for") },
   async ({ source_code }) => {
     const model = MODEL_ROUTES["test-scaffold"];
     const prompt = PROMPTS["test-scaffold"](source_code);
@@ -389,7 +389,7 @@ server.tool(
 server.tool(
   "ollama_lint_fix",
   "Fix lint errors in a file using a local 3B model. Preserves all logic and behavior — only fixes reported errors.",
-  { file_and_errors: z.string().describe("The file content followed by the lint errors to fix") },
+  { file_and_errors: z.string().max(500000).describe("The file content followed by the lint errors to fix") },
   async ({ file_and_errors }) => {
     const model = MODEL_ROUTES["lint-fix"];
     const prompt = PROMPTS["lint-fix"](file_and_errors);
@@ -418,7 +418,7 @@ server.tool(
 server.tool(
   "ollama_logic_refactor",
   "Refactor a code block for clarity and maintainability using a local 3B model. Preserves behavior and public interfaces.",
-  { code: z.string().describe("The code to refactor") },
+  { code: z.string().max(500000).describe("The code to refactor") },
   async ({ code }) => {
     const model = MODEL_ROUTES["logic-refactor"];
     const prompt = PROMPTS["logic-refactor"](code);

--- a/tools/tui/main.go
+++ b/tools/tui/main.go
@@ -1079,7 +1079,10 @@ fi
 bash "$SCRIPT"
 `
 		cmd := exec.Command("bash", "-c", script, "bash", tag)
-		_, err := cmd.CombinedOutput()
+		out, err := cmd.CombinedOutput()
+		if err != nil && len(out) > 0 {
+			err = fmt.Errorf("%w: %s", err, string(out))
+		}
 		return updateDoneMsg{err: err}
 	}
 }

--- a/tools/tui/main.go
+++ b/tools/tui/main.go
@@ -1043,10 +1043,37 @@ func checkLatestVersion() tea.Cmd {
 	}
 }
 
-func runSelfUpdate() tea.Cmd {
+func runSelfUpdate(tag string) tea.Cmd {
 	return func() tea.Msg {
-		cmd := exec.Command("bash", "-c",
-			`t=$(mktemp) && curl -sSL https://raw.githubusercontent.com/canoo/agent-nexus/main/install.sh -o "$t" && bash "$t"; rm -f "$t"`)
+		// Download install.sh and its checksum from the versioned release tag,
+		// verify integrity before executing — mirrors the pattern in install.sh itself.
+		script := `
+set -e
+TAG="` + tag + `"
+BASE="https://github.com/canoo/agent-nexus/releases/download/v${TAG}"
+SCRIPT=$(mktemp)
+SUMS=$(mktemp)
+trap 'rm -f "$SCRIPT" "$SUMS"' EXIT
+
+curl -sSL "${BASE}/install.sh"      -o "$SCRIPT"
+curl -sSL "${BASE}/checksums.txt"   -o "$SUMS"
+
+EXPECTED=$(awk '$2 == "install.sh" {print $1}' "$SUMS")
+if [ -z "$EXPECTED" ]; then
+  echo "checksum entry for install.sh not found" >&2; exit 1
+fi
+
+if command -v shasum >/dev/null 2>&1; then
+  echo "$EXPECTED  $SCRIPT" | shasum -a 256 --check --status
+elif command -v sha256sum >/dev/null 2>&1; then
+  echo "$EXPECTED  $SCRIPT" | sha256sum --check --status
+else
+  echo "no sha256 tool available" >&2; exit 1
+fi
+
+bash "$SCRIPT"
+`
+		cmd := exec.Command("bash", "-c", script)
 		_, err := cmd.CombinedOutput()
 		return updateDoneMsg{err: err}
 	}
@@ -1095,7 +1122,7 @@ func updateUpdateScreen(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 				m.running = true
 				m.output = ""
 				m.err = nil
-				return m, tea.Batch(m.spinner.Tick, runSelfUpdate())
+				return m, tea.Batch(m.spinner.Tick, runSelfUpdate(m.latestVersion))
 			}
 		}
 	}

--- a/tools/tui/main.go
+++ b/tools/tui/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1043,13 +1044,17 @@ func checkLatestVersion() tea.Cmd {
 	}
 }
 
+var validTag = regexp.MustCompile(`^[0-9A-Za-z._-]+$`)
+
 func runSelfUpdate(tag string) tea.Cmd {
 	return func() tea.Msg {
-		// Download install.sh and its checksum from the versioned release tag,
-		// verify integrity before executing — mirrors the pattern in install.sh itself.
+		if !validTag.MatchString(tag) {
+			return updateDoneMsg{err: fmt.Errorf("invalid version tag: %q", tag)}
+		}
+		// tag is passed as $1 so it is never interpolated into the script text.
 		script := `
 set -e
-TAG="` + tag + `"
+TAG="$1"
 BASE="https://github.com/canoo/agent-nexus/releases/download/v${TAG}"
 SCRIPT=$(mktemp)
 SUMS=$(mktemp)
@@ -1073,7 +1078,7 @@ fi
 
 bash "$SCRIPT"
 `
-		cmd := exec.Command("bash", "-c", script)
+		cmd := exec.Command("bash", "-c", script, "bash", tag)
 		_, err := cmd.CombinedOutput()
 		return updateDoneMsg{err: err}
 	}


### PR DESCRIPTION
## Summary

Closes all three open issues in the v0.1.6 — Security Fixes milestone.

- **#54** `install.sh`: binary is now downloaded to a `mktemp` temp file, checksum is verified against the temp path, and only after passing is the file `mv`'d to `$INSTALL_DIR/nexus`. Previously a failed checksum-file download would leave an unverified binary at the install destination.
- **#57** `demo.yml`: removed the `GIF_TOKEN` PAT from the checkout step. `GITHUB_TOKEN` with the existing `permissions: contents: write` grant is sufficient. If branch protection ever blocks bot pushes to main, add `github-actions[bot]` to the bypass list rather than reintroducing a PAT.
- **#51** `core/NEXUS.md` + `core/kiro-nexus-steering.md`: corrected `tools/automation/ollama-delegate.sh` → `tools/utilities/ollama-delegate.sh`. The `tools/automation/` directory never existed.

## Test plan

- [ ] Verify `shellcheck install.sh` passes (no new warnings from temp-file changes)
- [ ] Confirm demo workflow runs successfully with `GITHUB_TOKEN` on next `demo.tape` push — if branch protection blocks the bot push, add `github-actions[bot]` to the bypass list
- [ ] Confirm `tools/utilities/ollama-delegate.sh` exists at the documented path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI checkout authentication behavior
  * Improved installation script to download, verify, and atomically install binaries for more reliable updates
* **Improvement**
  * Self-update in the TUI is now version-aware and verifies integrity before running updates
* **Documentation**
  * Updated local delegation instructions to reflect reorganized script location
* **Bug Fixes**
  * Tightened input validation for several tools to improve robustness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->