### PR TITLE
fix: resolve issues #36 and #37 for v0.1.6 milestone

### DIFF
--- a/tools/mcp/server.mjs
+++ b/tools/mcp/server.mjs
@@ -196,7 +196,7 @@ server.tool(
 server.tool(
   "ollama_commit_msg",
   "Generate a conventional commit message from a git diff using a local 1.5B model. Use this instead of writing commit messages with cloud models.",
-  { diff: z.string().describe("The git diff to summarize") },
+  { diff: z.string().max(500000).describe("The git diff to summarize") },
   async ({ diff }) => {
     const model = MODEL_ROUTES["commit-msg"];
     const prompt = PROMPTS["commit-msg"](diff);
@@ -222,7 +222,7 @@ server.tool(
 server.tool(
   "ollama_boilerplate",
   "Generate a clean boilerplate file from a specification using a local 1.5B model. Use for component/route/model scaffolding.",
-  { specification: z.string().describe("Description of the boilerplate to generate, including framework and patterns to follow") },
+  { specification: z.string().max(500000).describe("Description of the boilerplate to generate, including framework and patterns to follow") },
   async ({ specification }) => {
     const model = MODEL_ROUTES["boilerplate"];
     const prompt = PROMPTS["boilerplate"](specification);
@@ -248,7 +248,7 @@ server.tool(
 server.tool(
   "ollama_test_scaffold",
   "Generate a test file scaffold (describe blocks, test names, no implementations) from a source file using a local 1.5B model.",
-  { source_code: z.string().describe("The source file content to generate tests for") },
+  { source_code: z.string().max(500000).describe("The source file content to generate tests for") },
   async ({ source_code }) => {
     const model = MODEL_ROUTES["test-scaffold"];
     const prompt = PROMPTS["test-scaffold"](source_code);
@@ -274,7 +274,7 @@ server.tool(
 server.tool(
   "ollama_lint_fix",
   "Fix lint errors in a file using a local 3B model. Preserves all logic and behavior — only fixes reported errors.",
-  { file_and_errors: z.string().describe("The file content followed by the lint errors to fix") },
+  { file_and_errors: z.string().max(500000).describe("The file content followed by the lint errors to fix") },
   async ({ file_and_errors }) => {
     const model = MODEL_ROUTES["lint-fix"];
     const prompt = PROMPTS["lint-fix"](file_and_errors);
@@ -300,7 +300,7 @@ server.tool(
 server.tool(
   "ollama_logic_refactor",
   "Refactor a code block for clarity and maintainability using a local 3B model. Preserves behavior and public interfaces.",
-  { code: z.string().describe("The code to refactor") },
+  { code: z.string().max(500000).describe("The code to refactor") },
   async ({ code }) => {
     const model = MODEL_ROUTES["logic-refactor"];
     const prompt = PROMPTS["logic-refactor"](code);

--- a/tools/tui/main.go
+++ b/tools/tui/main.go
@@ -816,10 +816,37 @@ func checkLatestVersion() tea.Cmd {
 	}
 }
 
-func runSelfUpdate() tea.Cmd {
+func runSelfUpdate(tag string) tea.Cmd {
 	return func() tea.Msg {
-		cmd := exec.Command("bash", "-c",
-			`t=$(mktemp) && curl -sSL https://raw.githubusercontent.com/canoo/agent-nexus/main/install.sh -o "$t" && bash "$t"; rm -f "$t"`)
+		// Download install.sh and its checksum from the versioned release tag,
+		// verify integrity before executing — mirrors the pattern in install.sh itself.
+		script := `
+set -e
+TAG="` + tag + `"
+BASE="https://github.com/canoo/agent-nexus/releases/download/v${TAG}"
+SCRIPT=$(mktemp)
+SUMS=$(mktemp)
+trap 'rm -f "$SCRIPT" "$SUMS"' EXIT
+
+curl -sSL "${BASE}/install.sh"      -o "$SCRIPT"
+curl -sSL "${BASE}/checksums.txt"   -o "$SUMS"
+
+EXPECTED=$(awk '$2 == "install.sh" {print $1}' "$SUMS")
+if [ -z "$EXPECTED" ]; then
+  echo "checksum entry for install.sh not found" >&2; exit 1
+fi
+
+if command -v shasum >/dev/null 2>&1; then
+  echo "$EXPECTED  $SCRIPT" | shasum -a 256 --check --status
+elif command -v sha256sum >/dev/null 2>&1; then
+  echo "$EXPECTED  $SCRIPT" | sha256sum --check --status
+else
+  echo "no sha256 tool available" >&2; exit 1
+fi
+
+bash "$SCRIPT"
+`
+		cmd := exec.Command("bash", "-c", script)
 		_, err := cmd.CombinedOutput()
 		return updateDoneMsg{err: err}
 	}
@@ -868,7 +895,7 @@ func updateUpdateScreen(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 				m.running = true
 				m.output = ""
 				m.err = nil
-				return m, tea.Batch(m.spinner.Tick, runSelfUpdate())
+				return m, tea.Batch(m.spinner.Tick, runSelfUpdate(m.latestVersion))
 			}
 		}
 	}


### PR DESCRIPTION
Two atomic commits targeting the v0.1.6 security milestone.

## fix(mcp): add Zod .max(500000) limits to all tool string inputs — closes #36

All 5 tool inputs in `tools/mcp/server.mjs` used unbounded `z.string()`. Added `.max(500000)` to cap payload size and prevent memory exhaustion on the Ollama host.

## fix(tui): verify install.sh checksum before executing self-update — closes #37

`runSelfUpdate` was downloading `install.sh` from the raw GitHub CDN and executing it immediately — a MITM could run arbitrary code during an update.

Now downloads `install.sh` + `checksums.txt` from the **versioned release tag** (not `main`), verifies SHA-256 before executing. Uses `shasum` on macOS and `sha256sum` on Linux, consistent with `install.sh` itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Input validation limits added to AI-powered tools (500MB maximum)
  * Self-update operations now include checksum validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->