### PR TITLE
feat: add observability task summary foundation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,8 @@ Make routing decisions visible. Without data, we can't improve. This milestone c
 - **TUI dashboard** — live view of model usage and routing stats (#10)
 - **Cost tracker** — monitor cloud API spend vs local compute savings; estimate "what this would have cost on cloud" for locally-routed tasks (#11)
 
+See [docs/observability-schema.md](docs/observability-schema.md) for the planned SQLite schema and JSONL migration path.
+
 ## v0.2.1 — CLI Usage Ingestion (via Tokscale)
 
 Extend observability to AI CLI tools by integrating [Tokscale](https://github.com/junhoyeo/tokscale) as an optional data provider. NEXUS shells out to `tokscale --json` and renders the data in its own TUI — Tokscale's TUI is never launched, and its social/leaderboard features are not integrated.

--- a/docs/observability-schema.md
+++ b/docs/observability-schema.md
@@ -1,0 +1,264 @@
+# Observability Schema
+
+NEXUS observability starts with the local routing events it owns directly:
+MCP tool calls, routing choices, local model latency, and estimated cloud-cost
+equivalents. The storage layer should support the v0.2.0 TUI dashboard while
+leaving room for proxy-intercepted requests in v0.3.0.
+
+## Goals
+
+- Track each task handled by NEXUS with model, route, latency, token counts, and
+  cost estimates.
+- Group tasks into sessions so CLI, MCP, and future proxy activity can be
+  inspected together.
+- Preserve routing rationale separately from task facts so the classifier/rules
+  engine can evolve without rewriting historical task rows.
+- Keep the database local-first under `~/.config/nexus/logs/`.
+- Provide stable aggregate queries for the TUI dashboard and cost tracker.
+
+## Storage
+
+The primary database is:
+
+```text
+~/.config/nexus/logs/observability.sqlite
+```
+
+The existing MCP JSONL log remains a compatibility source during migration:
+
+```text
+~/.config/nexus/logs/mcp-tasks.jsonl
+```
+
+Writers should prefer SQLite once implemented. Readers may fall back to JSONL
+until the migration is complete.
+
+## Entity Model
+
+```text
+sessions 1 -> many tasks
+tasks    1 -> many routing_decisions
+```
+
+`sessions` describe where a group of tasks came from. `tasks` describe what was
+executed and how it performed. `routing_decisions` describe why a route/model was
+selected, including rejected alternatives and fallback details.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    start_time TEXT NOT NULL,
+    end_time TEXT,
+    status TEXT,
+    cli_tool TEXT,       -- claude-code, gemini-cli, kiro-cli, proxy, mcp
+    persona TEXT,
+    nexus_mode TEXT,     -- hybrid, cloud, personas-only
+    project_path_hash TEXT,
+    nexus_version TEXT,
+    metadata_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    parent_task_id TEXT REFERENCES tasks(id),
+    timestamp TEXT NOT NULL,
+    source TEXT NOT NULL,       -- mcp-tool, proxy-intercept, manual
+    tool TEXT,
+    task_type TEXT,
+    model TEXT NOT NULL,
+    model_provider TEXT,        -- ollama, fast-path, openai, anthropic
+    route_band TEXT,            -- supervisor, logic, fast-path, cloud
+    routing TEXT NOT NULL,      -- cloud, local, deterministic
+    routing_reason TEXT,
+    trace_id TEXT,
+    span_id TEXT,
+    parent_span_id TEXT,
+    client_request_id TEXT,
+    upstream_session_id TEXT,
+    upstream_tool TEXT,
+    idempotency_key TEXT,
+    input_bytes INTEGER,
+    output_bytes INTEGER,
+    input_hash TEXT,
+    tokens_in INTEGER,
+    tokens_out INTEGER,
+    total_tokens INTEGER,
+    latency_ms INTEGER,
+    cost_usd REAL,
+    cloud_cost_equivalent REAL,
+    quality_rating INTEGER,     -- null, 1 helpful, 0 not helpful
+    ok INTEGER NOT NULL DEFAULT 1,
+    error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS routing_decisions (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL REFERENCES tasks(id),
+    decided_at TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    alternatives_considered TEXT, -- JSON array of {model, reason_rejected}
+    classifier_version TEXT,      -- rules-v1, ml-v1
+    fallback_from TEXT,
+    fallback_to TEXT,
+    circuit_breaker_triggered INTEGER NOT NULL DEFAULT 0,
+    latency_budget_ms INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_start_time
+    ON sessions(start_time);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_session_id
+    ON tasks(session_id);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_timestamp
+    ON tasks(timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_model
+    ON tasks(model);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status
+    ON tasks(ok);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_routing
+    ON tasks(routing);
+
+CREATE INDEX IF NOT EXISTS idx_routing_decisions_task_id
+    ON routing_decisions(task_id);
+```
+
+## Field Mapping From MCP JSONL
+
+Current `mcp-tasks.jsonl` entries look like:
+
+```json
+{"tool":"ollama_commit_msg","model":"qwen2.5-coder:1.5b","ms":42,"ok":true,"ts":1713890000000}
+```
+
+When importing those rows:
+
+| JSONL field | SQLite field |
+|---|---|
+| `tool` | `tasks.tool` |
+| `model` | `tasks.model` |
+| `ms` | `tasks.latency_ms` |
+| `ok` | `tasks.ok` |
+| `error` | `tasks.error` |
+| `ts` | `tasks.timestamp` |
+
+Imported MCP rows should use:
+
+| Field | Value |
+|---|---|
+| `sessions.cli_tool` | `mcp` |
+| `sessions.nexus_mode` | `hybrid` |
+| `tasks.source` | `mcp-tool` |
+| `tasks.routing` | `local`, or `deterministic` when `model = fast-path` |
+| `tasks.routing_reason` | `mcp:<tool-name>` |
+| `tasks.model_provider` | `ollama`, or `fast-path` when `model = fast-path` |
+| `routing_decisions.classifier_version` | `rules-v1` |
+
+The importer may create a synthetic daily session for legacy JSONL rows, for
+example `mcp-2026-06-27`, until real session identifiers are emitted.
+
+## Dashboard Queries
+
+Total tasks and success rate:
+
+```sql
+SELECT
+    COUNT(*) AS total,
+    SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS successes,
+    SUM(CASE WHEN ok = 0 THEN 1 ELSE 0 END) AS failures
+FROM tasks;
+```
+
+Average latency by model:
+
+```sql
+SELECT model, AVG(latency_ms) AS avg_latency_ms, COUNT(*) AS task_count
+FROM tasks
+GROUP BY model
+ORDER BY task_count DESC, model ASC;
+```
+
+P95 latency can be computed in the TUI from the ordered `latency_ms` values
+until NEXUS adds a dedicated aggregate helper.
+
+Local routing savings:
+
+```sql
+SELECT
+    SUM(COALESCE(cloud_cost_equivalent, 0)) - SUM(COALESCE(cost_usd, 0))
+        AS estimated_savings_usd
+FROM tasks
+WHERE routing IN ('local', 'deterministic');
+```
+
+Recent session activity:
+
+```sql
+SELECT
+    s.id,
+    s.start_time,
+    s.cli_tool,
+    COUNT(t.id) AS tasks,
+    AVG(t.latency_ms) AS avg_latency_ms
+FROM sessions s
+LEFT JOIN tasks t ON t.session_id = s.id
+GROUP BY s.id
+ORDER BY s.start_time DESC
+LIMIT 20;
+```
+
+## Migration Plan
+
+1. Add a small SQLite writer used by the MCP server for new task rows.
+2. Keep JSONL writes temporarily so older TUI builds can still display task
+   history.
+3. Add a one-time importer that reads `mcp-tasks.jsonl` and writes missing rows
+   into SQLite using deterministic task IDs.
+4. Update the TUI Task Log and dashboard screens to prefer SQLite and fall back
+   to JSONL when the database is absent.
+5. Remove JSONL writes only after one release cycle with SQLite enabled.
+
+## Cost Estimation
+
+For local tasks, `cost_usd` should normally be `0`. `cloud_cost_equivalent`
+should estimate what the same request would have cost on a configured cloud
+model. Early versions can use static pricing tables; later versions may ingest
+pricing from LiteLLM/Tokscale.
+
+Token counts may be null until NEXUS can measure them reliably. Cost queries
+must treat null values as unknown rather than zero unless the route is explicitly
+local or deterministic.
+
+## Privacy And Retention
+
+Observability must not become a secret sink. By default, do not store raw
+prompts, diffs, source files, generated code, environment variables, or provider
+API keys. Store sizes, hashes, model names, routing reasons, latency, status, and
+cost metadata instead.
+
+`input_hash` can be used to correlate repeated tasks without retaining the input
+itself. Hashes should be treated as metadata, not as a security boundary.
+
+SQLite retention should mirror the current JSONL rotation behavior at first:
+keep recent local history bounded, document the default, and make longer
+retention an explicit setting later.
+
+## Compatibility Notes
+
+- Keep timestamps in UTC RFC3339 text in SQLite. Legacy millisecond timestamps
+  are converted during import.
+- Keep unknown values nullable rather than inventing fake token or cost numbers.
+- Store routing alternatives as JSON text so Go, Node.js, and shell tooling can
+  read/write the database without a custom extension.
+- Do not require network access for observability storage.

--- a/tools/mcp/server.mjs
+++ b/tools/mcp/server.mjs
@@ -31,6 +31,41 @@ function logTask(entry) {
   } catch {}
 }
 
+// Early cost tracking uses a conservative cloud-equivalent estimate. Local
+// Ollama tasks cost $0 here; this value answers "what would this have cost if
+// routed to a typical cloud coding model?" until provider-specific pricing lands.
+const CLOUD_INPUT_USD_PER_1M = 3.0;
+const CLOUD_OUTPUT_USD_PER_1M = 15.0;
+
+function estimateTokens(text) {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+function estimateCloudCost(tokensIn, tokensOut) {
+  return (tokensIn / 1_000_000) * CLOUD_INPUT_USD_PER_1M +
+    (tokensOut / 1_000_000) * CLOUD_OUTPUT_USD_PER_1M;
+}
+
+function taskLogEntry({ tool, model, ms, ok, prompt = "", response = "", error }) {
+  const tokensIn = estimateTokens(prompt);
+  const tokensOut = estimateTokens(response);
+  const routing = model === "fast-path" ? "deterministic" : "local";
+  const entry = {
+    tool,
+    model,
+    routing,
+    tokens_in: tokensIn,
+    tokens_out: tokensOut,
+    cloud_cost_equivalent: estimateCloudCost(tokensIn, tokensOut),
+    ms,
+    ok,
+    ts: Date.now(),
+  };
+  if (error) entry.error = error;
+  return entry;
+}
+
 // ── Model routing table ─────────────────────────────────────────────────────
 // Matches ollama-delegate.sh: supervisor band (1.5B) for fast tasks,
 // logic band (3B) for heavier reasoning.
@@ -301,7 +336,14 @@ server.tool(
     // Fast-path: deterministic commit messages for trivial diffs
     const fastResult = fastPathCommitMsg(diff);
     if (fastResult) {
-      logTask({ tool: "ollama_commit_msg", model: "fast-path", ms: 0, ok: true, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_commit_msg",
+        model: "fast-path",
+        ms: 0,
+        ok: true,
+        prompt: diff,
+        response: fastResult,
+      }));
       return { content: [{ type: "text", text: fastResult }] };
     }
     const model = MODEL_ROUTES["commit-msg"];
@@ -309,14 +351,28 @@ server.tool(
     try {
       const start = Date.now();
       const result = await callOllama(model, prompt, "commit-msg");
-      logTask({ tool: "ollama_commit_msg", model, ms: Date.now() - start, ok: true, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_commit_msg",
+        model,
+        ms: Date.now() - start,
+        ok: true,
+        prompt,
+        response: result,
+      }));
       return {
         content: [
           { type: "text", text: result },
         ],
       };
     } catch (e) {
-      logTask({ tool: "ollama_commit_msg", model, ms: 0, ok: false, error: e.message, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_commit_msg",
+        model,
+        ms: 0,
+        ok: false,
+        prompt,
+        error: e.message,
+      }));
       return {
         content: [
           { type: "text", text: `CIRCUIT_BREAKER: ${e.message}` },
@@ -338,14 +394,28 @@ server.tool(
     try {
       const start = Date.now();
       const result = await callOllama(model, prompt, "boilerplate");
-      logTask({ tool: "ollama_boilerplate", model, ms: Date.now() - start, ok: true, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_boilerplate",
+        model,
+        ms: Date.now() - start,
+        ok: true,
+        prompt,
+        response: result,
+      }));
       return {
         content: [
           { type: "text", text: result },
         ],
       };
     } catch (e) {
-      logTask({ tool: "ollama_boilerplate", model, ms: 0, ok: false, error: e.message, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_boilerplate",
+        model,
+        ms: 0,
+        ok: false,
+        prompt,
+        error: e.message,
+      }));
       return {
         content: [
           { type: "text", text: `CIRCUIT_BREAKER: ${e.message}` },
@@ -367,14 +437,28 @@ server.tool(
     try {
       const start = Date.now();
       const result = await callOllama(model, prompt, "test-scaffold");
-      logTask({ tool: "ollama_test_scaffold", model, ms: Date.now() - start, ok: true, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_test_scaffold",
+        model,
+        ms: Date.now() - start,
+        ok: true,
+        prompt,
+        response: result,
+      }));
       return {
         content: [
           { type: "text", text: result },
         ],
       };
     } catch (e) {
-      logTask({ tool: "ollama_test_scaffold", model, ms: 0, ok: false, error: e.message, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_test_scaffold",
+        model,
+        ms: 0,
+        ok: false,
+        prompt,
+        error: e.message,
+      }));
       return {
         content: [
           { type: "text", text: `CIRCUIT_BREAKER: ${e.message}` },
@@ -396,14 +480,28 @@ server.tool(
     try {
       const start = Date.now();
       const result = await callOllama(model, prompt, "lint-fix");
-      logTask({ tool: "ollama_lint_fix", model, ms: Date.now() - start, ok: true, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_lint_fix",
+        model,
+        ms: Date.now() - start,
+        ok: true,
+        prompt,
+        response: result,
+      }));
       return {
         content: [
           { type: "text", text: result },
         ],
       };
     } catch (e) {
-      logTask({ tool: "ollama_lint_fix", model, ms: 0, ok: false, error: e.message, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_lint_fix",
+        model,
+        ms: 0,
+        ok: false,
+        prompt,
+        error: e.message,
+      }));
       return {
         content: [
           { type: "text", text: `CIRCUIT_BREAKER: ${e.message}` },
@@ -425,14 +523,28 @@ server.tool(
     try {
       const start = Date.now();
       const result = await callOllama(model, prompt, "logic-refactor");
-      logTask({ tool: "ollama_logic_refactor", model, ms: Date.now() - start, ok: true, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_logic_refactor",
+        model,
+        ms: Date.now() - start,
+        ok: true,
+        prompt,
+        response: result,
+      }));
       return {
         content: [
           { type: "text", text: result },
         ],
       };
     } catch (e) {
-      logTask({ tool: "ollama_logic_refactor", model, ms: 0, ok: false, error: e.message, ts: Date.now() });
+      logTask(taskLogEntry({
+        tool: "ollama_logic_refactor",
+        model,
+        ms: 0,
+        ok: false,
+        prompt,
+        error: e.message,
+      }));
       return {
         content: [
           { type: "text", text: `CIRCUIT_BREAKER: ${e.message}` },

--- a/tools/tui/main.go
+++ b/tools/tui/main.go
@@ -95,6 +95,14 @@ type taskLogMsg struct {
 	entries []taskLogEntry
 }
 
+type taskLogStats struct {
+	total      int
+	successes  int
+	failures   int
+	avgMs      int
+	modelTasks map[string]int
+}
+
 // --- GPU detection ---
 
 type gpuInfo struct {
@@ -250,9 +258,9 @@ type model struct {
 	localAIAsked bool // true after user answered the prompt during install
 
 	// uninstall / generic operation
-	running           bool
-	output            string
-	err               error
+	running            bool
+	output             string
+	err                error
 	uninstallConfirmed bool
 
 	// health
@@ -854,6 +862,15 @@ func taskLogView(m model) string {
 		s += m.styles.subtle.Render("No MCP tasks recorded yet.") + "\n"
 		s += m.styles.subtle.Render("Tasks appear here when AI tools use the nexus-ollama MCP server.") + "\n"
 	} else {
+		stats := summarizeTaskLog(m.taskLog)
+		successRate := 0
+		if stats.total > 0 {
+			successRate = stats.successes * 100 / stats.total
+		}
+		s += fmt.Sprintf("  Tasks: %d  Success: %d%%  Failures: %d  Avg latency: %dms\n",
+			stats.total, successRate, stats.failures, stats.avgMs)
+		s += fmt.Sprintf("  Models: %s\n\n", summarizeModelUsage(stats.modelTasks, 3))
+
 		// Header
 		s += fmt.Sprintf("  %-24s %-22s %8s  %s\n",
 			"Tool", "Model", "Time", "Status")
@@ -874,6 +891,66 @@ func taskLogView(m model) string {
 	}
 	s += "\n" + m.styles.subtle.Render("r: refresh • esc: back")
 	return m.borderBox(s)
+}
+
+func summarizeTaskLog(entries []taskLogEntry) taskLogStats {
+	stats := taskLogStats{modelTasks: map[string]int{}}
+	if len(entries) == 0 {
+		return stats
+	}
+
+	totalMs := 0
+	for _, e := range entries {
+		stats.total++
+		totalMs += e.Ms
+		if e.Ok {
+			stats.successes++
+		} else {
+			stats.failures++
+		}
+		model := strings.TrimSpace(e.Model)
+		if model == "" {
+			model = "unknown"
+		}
+		stats.modelTasks[model]++
+	}
+	stats.avgMs = totalMs / stats.total
+	return stats
+}
+
+func summarizeModelUsage(modelTasks map[string]int, maxModels int) string {
+	if len(modelTasks) == 0 {
+		return "none"
+	}
+
+	type modelCount struct {
+		model string
+		count int
+	}
+	counts := make([]modelCount, 0, len(modelTasks))
+	for model, count := range modelTasks {
+		counts = append(counts, modelCount{model: model, count: count})
+	}
+	for i := 0; i < len(counts); i++ {
+		for j := i + 1; j < len(counts); j++ {
+			if counts[j].count > counts[i].count ||
+				(counts[j].count == counts[i].count && counts[j].model < counts[i].model) {
+				counts[i], counts[j] = counts[j], counts[i]
+			}
+		}
+	}
+
+	if maxModels <= 0 || maxModels > len(counts) {
+		maxModels = len(counts)
+	}
+	parts := make([]string, 0, maxModels+1)
+	for i := 0; i < maxModels; i++ {
+		parts = append(parts, fmt.Sprintf("%s (%d)", counts[i].model, counts[i].count))
+	}
+	if len(counts) > maxModels {
+		parts = append(parts, fmt.Sprintf("+%d more", len(counts)-maxModels))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // --- uninstall (original) ---

--- a/tools/tui/main.go
+++ b/tools/tui/main.go
@@ -83,12 +83,16 @@ type healthMsg struct {
 // --- task log ---
 
 type taskLogEntry struct {
-	Tool  string `json:"tool"`
-	Model string `json:"model"`
-	Ms    int    `json:"ms"`
-	Ok    bool   `json:"ok"`
-	Error string `json:"error,omitempty"`
-	Ts    int64  `json:"ts"`
+	Tool                string  `json:"tool"`
+	Model               string  `json:"model"`
+	Routing             string  `json:"routing,omitempty"`
+	TokensIn            int     `json:"tokens_in,omitempty"`
+	TokensOut           int     `json:"tokens_out,omitempty"`
+	CloudCostEquivalent float64 `json:"cloud_cost_equivalent,omitempty"`
+	Ms                  int     `json:"ms"`
+	Ok                  bool    `json:"ok"`
+	Error               string  `json:"error,omitempty"`
+	Ts                  int64   `json:"ts"`
 }
 
 type taskLogMsg struct {
@@ -101,6 +105,7 @@ type taskLogStats struct {
 	failures   int
 	avgMs      int
 	modelTasks map[string]int
+	savingsUSD float64
 }
 
 // --- GPU detection ---
@@ -869,6 +874,9 @@ func taskLogView(m model) string {
 		}
 		s += fmt.Sprintf("  Tasks: %d  Success: %d%%  Failures: %d  Avg latency: %dms\n",
 			stats.total, successRate, stats.failures, stats.avgMs)
+		if stats.savingsUSD > 0 {
+			s += fmt.Sprintf("  Est. local savings: $%.4f\n", stats.savingsUSD)
+		}
 		s += fmt.Sprintf("  Models: %s\n\n", summarizeModelUsage(stats.modelTasks, 3))
 
 		// Header
@@ -907,6 +915,9 @@ func summarizeTaskLog(entries []taskLogEntry) taskLogStats {
 			stats.successes++
 		} else {
 			stats.failures++
+		}
+		if e.Routing == "local" || e.Routing == "deterministic" {
+			stats.savingsUSD += e.CloudCostEquivalent
 		}
 		model := strings.TrimSpace(e.Model)
 		if model == "" {

--- a/tools/tui/main_test.go
+++ b/tools/tui/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -297,9 +298,9 @@ func TestViewsDoNotPanic(t *testing.T) {
 
 func TestSummarizeTaskLog(t *testing.T) {
 	entries := []taskLogEntry{
-		{Tool: "ollama_commit_msg", Model: "qwen2.5-coder:1.5b", Ms: 10, Ok: true},
-		{Tool: "ollama_boilerplate", Model: "qwen2.5-coder:1.5b", Ms: 20, Ok: true},
-		{Tool: "ollama_lint_fix", Model: "llama3.2:3b", Ms: 30, Ok: false},
+		{Tool: "ollama_commit_msg", Model: "qwen2.5-coder:1.5b", Routing: "local", CloudCostEquivalent: 0.001, Ms: 10, Ok: true},
+		{Tool: "ollama_boilerplate", Model: "qwen2.5-coder:1.5b", Routing: "local", CloudCostEquivalent: 0.002, Ms: 20, Ok: true},
+		{Tool: "ollama_lint_fix", Model: "llama3.2:3b", Routing: "local", CloudCostEquivalent: 0.003, Ms: 30, Ok: false},
 	}
 
 	stats := summarizeTaskLog(entries)
@@ -314,6 +315,9 @@ func TestSummarizeTaskLog(t *testing.T) {
 	}
 	if stats.avgMs != 20 {
 		t.Errorf("avgMs: got %d, want 20", stats.avgMs)
+	}
+	if math.Abs(stats.savingsUSD-0.006) > 0.000001 {
+		t.Errorf("savingsUSD: got %f, want 0.006", stats.savingsUSD)
 	}
 	if stats.modelTasks["qwen2.5-coder:1.5b"] != 2 {
 		t.Errorf("qwen count: got %d, want 2", stats.modelTasks["qwen2.5-coder:1.5b"])

--- a/tools/tui/main_test.go
+++ b/tools/tui/main_test.go
@@ -295,6 +295,48 @@ func TestViewsDoNotPanic(t *testing.T) {
 	}
 }
 
+func TestSummarizeTaskLog(t *testing.T) {
+	entries := []taskLogEntry{
+		{Tool: "ollama_commit_msg", Model: "qwen2.5-coder:1.5b", Ms: 10, Ok: true},
+		{Tool: "ollama_boilerplate", Model: "qwen2.5-coder:1.5b", Ms: 20, Ok: true},
+		{Tool: "ollama_lint_fix", Model: "llama3.2:3b", Ms: 30, Ok: false},
+	}
+
+	stats := summarizeTaskLog(entries)
+	if stats.total != 3 {
+		t.Errorf("total: got %d, want 3", stats.total)
+	}
+	if stats.successes != 2 {
+		t.Errorf("successes: got %d, want 2", stats.successes)
+	}
+	if stats.failures != 1 {
+		t.Errorf("failures: got %d, want 1", stats.failures)
+	}
+	if stats.avgMs != 20 {
+		t.Errorf("avgMs: got %d, want 20", stats.avgMs)
+	}
+	if stats.modelTasks["qwen2.5-coder:1.5b"] != 2 {
+		t.Errorf("qwen count: got %d, want 2", stats.modelTasks["qwen2.5-coder:1.5b"])
+	}
+	if stats.modelTasks["llama3.2:3b"] != 1 {
+		t.Errorf("llama count: got %d, want 1", stats.modelTasks["llama3.2:3b"])
+	}
+}
+
+func TestSummarizeModelUsage(t *testing.T) {
+	got := summarizeModelUsage(map[string]int{
+		"llama3.2:3b":        1,
+		"qwen2.5-coder:1.5b": 3,
+		"fast-path":          2,
+		"qwen2.5:14b":        1,
+	}, 2)
+
+	want := "qwen2.5-coder:1.5b (3), fast-path (2), +2 more"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestBorderBoxClampsWidth(t *testing.T) {
 	m := initialModel()
 


### PR DESCRIPTION
## Summary

Starts the v0.2.0 observability milestone with three scoped pieces:

- adds Task Log summary stats in the TUI: total tasks, success rate, failures, average latency, top model usage, and estimated local savings when present
- documents the planned SQLite observability schema and JSONL migration path for #9
- enriches MCP task log entries with routing, token estimates, and cloud-cost-equivalent estimates without storing raw prompts or code

## Issues

- Progresses #9
- Progresses #10
- Lays groundwork for #11

## Verification

- `docker run --rm -v <repo>:/work -w /work/tools/tui golang:1.26.2 go test ./...`
- `docker run --rm -v <repo>:/work -w /work/tools/tui golang:1.26.2 go vet ./...`
- `node --check tools/mcp/server.mjs`
- `npm --prefix tools/mcp audit --audit-level=high`

## Notes

This intentionally keeps the current JSONL path compatible while defining the SQLite target. SQLite writing/importing can land as the next slice after the schema settles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an observability guide covering local storage, migration from JSONL, and example reporting queries.
  * The task log view now shows summary metrics like total tasks, success rate, failures, average latency, estimated savings, and top model usage.
  * Task records now include richer routing, token, cost, and timing details for easier tracking.

* **Tests**
  * Added coverage for task log aggregation and model usage summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->