### PR TITLE
docs: add community contributor callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev)
 [![Linux](https://img.shields.io/badge/Linux-supported-FCC624?style=flat-square&logo=linux&logoColor=black)](https://github.com/canoo/agent-nexus)
 [![macOS](https://img.shields.io/badge/macOS-supported-000000?style=flat-square&logo=apple&logoColor=white)](https://github.com/canoo/agent-nexus)
-[![Discord](https://img.shields.io/badge/Discord-Join%20community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/tpHCzpAwr)
+[![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/tpHCzpAwr)
 
 **Network of EXperts, Unified in Strategy**
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ NEXUS is an early open-source project and is actively looking for a few steady c
 
 | Role | Good fit if you like | Current focus |
 |---|---|---|
-| **Discord/community moderator** | Welcoming new users, collecting feedback, keeping discussions organized | Help shape community norms, surface useful bug reports, and turn recurring questions into docs or issues |
+| **Discord/community moderator** | Welcoming new users, collecting feedback, keeping discussions organized, setting up webhooks, and working with Discord bots or the Discord Developer Platform | Help shape community norms, surface useful bug reports, automate helpful community workflows, and turn recurring questions into docs or issues |
 | **Integrator** | Connecting tools, MCP servers, CLIs, and config formats | Help test NEXUS across Claude Code, Gemini CLI, Kiro, Cursor, Windsurf, Cline, Continue.dev, and local Ollama setups |
 | **Developer** | Go, Node.js, terminal UX, automation, or local AI workflows | Help with observability, tool sync, routing, tests, cross-platform support, and release polish |
 | **Documentation/discussion contributor** | Explaining workflows clearly and asking good product questions | Help write guides, forum posts, dependency proposals, and milestone summaries |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev)
 [![Linux](https://img.shields.io/badge/Linux-supported-FCC624?style=flat-square&logo=linux&logoColor=black)](https://github.com/canoo/agent-nexus)
 [![macOS](https://img.shields.io/badge/macOS-supported-000000?style=flat-square&logo=apple&logoColor=white)](https://github.com/canoo/agent-nexus)
+[![Discord](https://img.shields.io/badge/Discord-Join%20community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/tpHCzpAwr)
 
 **Network of EXperts, Unified in Strategy**
 
@@ -296,7 +297,7 @@ NEXUS is an early open-source project and is actively looking for a few steady c
 | **Developer** | Go, Node.js, terminal UX, automation, or local AI workflows | Help with observability, tool sync, routing, tests, cross-platform support, and release polish |
 | **Documentation/discussion contributor** | Explaining workflows clearly and asking good product questions | Help write guides, forum posts, dependency proposals, and milestone summaries |
 
-If any of that sounds useful, open a GitHub Discussion or pick up an issue from the current milestones. Small, focused contributions are welcome.
+If any of that sounds useful, [join the Discord](https://discord.gg/tpHCzpAwr), open a GitHub Discussion, or pick up an issue from the current milestones. Small, focused contributions are welcome.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ bash tests/test-install-cycle.sh
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, PR guidelines, and commit conventions.
 
+### Looking for contributors
+
+NEXUS is an early open-source project and is actively looking for a few steady contributors as the next milestones come together:
+
+| Role | Good fit if you like | Current focus |
+|---|---|---|
+| **Discord/community moderator** | Welcoming new users, collecting feedback, keeping discussions organized | Help shape community norms, surface useful bug reports, and turn recurring questions into docs or issues |
+| **Integrator** | Connecting tools, MCP servers, CLIs, and config formats | Help test NEXUS across Claude Code, Gemini CLI, Kiro, Cursor, Windsurf, Cline, Continue.dev, and local Ollama setups |
+| **Developer** | Go, Node.js, terminal UX, automation, or local AI workflows | Help with observability, tool sync, routing, tests, cross-platform support, and release polish |
+| **Documentation/discussion contributor** | Explaining workflows clearly and asking good product questions | Help write guides, forum posts, dependency proposals, and milestone summaries |
+
+If any of that sounds useful, open a GitHub Discussion or pick up an issue from the current milestones. Small, focused contributions are welcome.
+
 ## Security
 
 See [SECURITY.md](SECURITY.md) for vulnerability reporting.

--- a/docs/discussion-posts/community-help-wanted.md
+++ b/docs/discussion-posts/community-help-wanted.md
@@ -16,12 +16,14 @@ The main areas where help would be useful:
 
 ## Discord/community moderator
 
-Someone who can help keep community discussion organized, welcome new users, collect common questions, and turn recurring feedback into docs, issues, or milestone notes.
+Someone who can help keep community discussion organized, welcome new users, collect common questions, and turn recurring feedback into docs, issues, or milestone notes. Discord webhook, bot, and Developer Platform experience would also be helpful as the community tooling grows.
 
 Good fit if you like:
 
 - Helping users get unstuck
 - Keeping discussions friendly and on topic
+- Setting up Discord webhooks and lightweight automations
+- Working with Discord bots or the Discord Developer Platform
 - Turning vague feedback into clear issues
 - Helping define community norms early
 

--- a/docs/discussion-posts/community-help-wanted.md
+++ b/docs/discussion-posts/community-help-wanted.md
@@ -1,0 +1,65 @@
+# Discussion Draft: Help Wanted for NEXUS Contributors
+
+Title ideas:
+
+- Help wanted: Discord/community mod, integrator, and developer contributors
+- Looking for contributors for the next NEXUS milestones
+- NEXUS is active again: looking for community help
+
+Post:
+
+Hey everyone, quick project update: I was away for school and final exams for a bit, but I am back to working on NEXUS again. I am going through open PRs, checking the recent merges, and planning the next milestone work.
+
+I would like to start building a small contributor group around the project. NEXUS is still early, so there is room to shape both the technical direction and the community workflow.
+
+The main areas where help would be useful:
+
+## Discord/community moderator
+
+Someone who can help keep community discussion organized, welcome new users, collect common questions, and turn recurring feedback into docs, issues, or milestone notes.
+
+Good fit if you like:
+
+- Helping users get unstuck
+- Keeping discussions friendly and on topic
+- Turning vague feedback into clear issues
+- Helping define community norms early
+
+## Integrator
+
+Someone who enjoys testing how tools fit together. NEXUS touches AI coding tools, MCP servers, config formats, local Ollama models, and CLI workflows, so integration testing is a big part of the project.
+
+Good fit if you like:
+
+- Trying NEXUS with Claude Code, Gemini CLI, Kiro, Cursor, Windsurf, Cline, Continue.dev, or Ollama
+- Testing install/update flows
+- Finding config edge cases
+- Writing compatibility notes and setup guides
+
+## Developer
+
+Another developer would be a huge help as the next milestones move forward.
+
+Good fit if you like:
+
+- Go terminal apps
+- Node.js MCP servers
+- Local AI workflows
+- Observability and usage dashboards
+- GitHub Actions and release automation
+- Cross-platform support
+
+Near-term technical areas include observability, task logging, usage/cost summaries, tool sync, routing improvements, and release polish.
+
+## Discussion/docs contributor
+
+I am also interested in help turning ideas into good GitHub Discussions: dependency proposals, integration ideas, roadmap questions, and milestone updates.
+
+Good fit if you like:
+
+- Writing clear technical posts
+- Asking product/design questions
+- Comparing open-source dependencies
+- Helping turn community discussion into actionable issues
+
+If you are interested, reply here with what area you would like to help with. Small contributions are welcome, and I am happy to help turn ideas into first issues or focused PRs.


### PR DESCRIPTION
## Summary

- Add a README section for contributors NEXUS is actively looking for: Discord/community moderator, integrator, developer, and discussion/docs contributor.
- Add a reusable GitHub Discussion draft announcing that project work is active again after school/finals and inviting people to help with community, integration, development, and discussion posts.

## Validation

- Ran `git diff --check -- README.md docs/discussion-posts/community-help-wanted.md`.

## Notes

This is docs-only and intended as a draft for review before merging.