### PR TITLE
fix(docs): correct ollama delegate paths

### DIFF
--- a/core/NEXUS.md
+++ b/core/NEXUS.md
@@ -157,7 +157,7 @@ If any `ollama_*` tool returns `CIRCUIT_BREAKER`, fall back to handling the task
 
 If MCP is not available, the same delegation can be done manually via:
 ```bash
-bash ~/.config/nexus/tools/utilities/ollama-delegate.sh <task-type> <context-file>
+bash ~/.config/nexus/tools/automation/ollama-delegate.sh <task-type> <context-file>
 ```
 
 ---

--- a/core/kiro-nexus-steering.md
+++ b/core/kiro-nexus-steering.md
@@ -158,5 +158,5 @@ If any `ollama_*` tool returns `CIRCUIT_BREAKER`, fall back to handling the task
 
 If MCP is not available, the same delegation can be done manually via:
 ```bash
-bash ~/.config/nexus/tools/utilities/ollama-delegate.sh <task-type> <context-file>
+bash ~/.config/nexus/tools/automation/ollama-delegate.sh <task-type> <context-file>
 ```

--- a/tools/automation/run-pipeline.sh
+++ b/tools/automation/run-pipeline.sh
@@ -117,7 +117,7 @@ build_prompt() {
   # Ollama availability note for the orchestrator
   local ollama_note=""
   if [ -n "${OLLAMA_HOST_URL:-}" ]; then
-    ollama_note="**L1 LOCAL MODELS AVAILABLE** — scripts/ollama-delegate.sh is configured at ${OLLAMA_HOST_URL}.
+    ollama_note="**L1 LOCAL MODELS AVAILABLE** — tools/automation/ollama-delegate.sh is configured at ${OLLAMA_HOST_URL}.
 Use it (via Bash tool) for: commit-msg, boilerplate, test-scaffold, lint-fix, logic-refactor tasks.
 Circuit breaker rules — when ollama-delegate.sh exits with code 3:
   1. Immediately echo to console: 'WARN: Local Ollama unreachable. Tripping circuit breaker.'
@@ -237,7 +237,7 @@ Commits to execute in order:
 
 Commit-type & Tag → specialist routing:
 - FIRST, check for the [L1] tag in the commit message or goal. 
-  → If [L1] is present: You MUST execute this task locally using the Bash tool to call \`scripts/ollama-delegate.sh "\$OLLAMA_HOST_URL" "<task_description>"\`. Do NOT spawn an Anthropic agent for [L1] tasks.
+  → If [L1] is present: You MUST execute this task locally using the Bash tool to write the task context to a temporary file, then call \`tools/automation/ollama-delegate.sh "<task-type>" "<context-file>"\`. Do NOT pass OLLAMA_HOST_URL as an argument; the script reads it from the environment. Do NOT spawn an Anthropic agent for [L1] tasks.
 - If NO [L1] tag, route by commit type:
   - feat:/fix: on frontend/UI files  → frontend-developer
   - feat:/fix: on backend/API files  → engineering-backend-architect


### PR DESCRIPTION
## Summary

- Correct stale `ollama-delegate.sh` references from `tools/utilities/` and `scripts/` to the current `tools/automation/` path.
- Correct the pipeline prompt so L1 task delegation uses the script's actual `<task-type> <context-file>` arguments instead of passing `OLLAMA_HOST_URL` as an argument.

## Security branch audit

Audited `origin/release/v0.1.6-security-fixes` against current `main`.

Already present on `main` in current form:

- Installer downloads binaries to a temp file before checksum verification.
- Installer temp binary is created in `INSTALL_DIR` for atomic move behavior.
- Installer cleanup trap is present.
- MCP string inputs have `.max(500000)` bounds.
- TUI self-update downloads `install.sh` from the versioned release tag and verifies it against `checksums.txt` before execution.
- TUI update tag validation and positional shell argument handling are present.
- TUI update error output is captured and surfaced.
- `.goreleaser.yml` includes `install.sh` in release checksums.

Skipped as obsolete:

- The old `demo.yml` PAT removal commit, because `demo.yml` no longer exists on `main`.

Remaining actionable item:

- Stale docs/instruction paths for `ollama-delegate.sh`, fixed in this PR.

## Validation

- `rg -n 'tools/utilities/ollama-delegate|scripts/ollama-delegate|OLLAMA_HOST_URL.*task_description' core tools README.md docs personas prompts tests` returned no matches.
- `git diff --check -- core/NEXUS.md core/kiro-nexus-steering.md tools/automation/run-pipeline.sh` passed.
- `docker run --rm -v "${PWD}:/repo" -w /repo koalaman/shellcheck:stable tools/automation/run-pipeline.sh` passed.